### PR TITLE
Fix tests path and optional dependency

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,9 +5,7 @@ Integration tests for the MCP HF Hackathon application
 import pytest
 import sys
 import os
-import requests
-import time
-from threading import Thread
+
 
 # Add src to path for imports
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
@@ -71,6 +69,9 @@ def test_model_configuration():
 @pytest.mark.slow
 def test_application_startup():
     """Test that the application can start without errors"""
+    # Skip test if gradio is not installed
+    pytest.importorskip("gradio")
+
     # This is a basic test to ensure imports work
     try:
         from components.interface import create_main_interface

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -7,7 +7,7 @@ import sys
 import os
 
 # Add src to path for imports
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from utils.config import load_config
 from utils.helpers import process_user_input, validate_model_name


### PR DESCRIPTION
## Summary
- fix unit test to import from src correctly
- remove unnecessary imports from integration tests and skip start-up test if `gradio` isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cfe47360832081f3bdb34f0c2228