### PR TITLE
Remove unused imports

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,9 +5,6 @@ Integration tests for the MCP HF Hackathon application
 import pytest
 import sys
 import os
-import requests
-import time
-from threading import Thread
 
 # Add src to path for imports
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "src"))


### PR DESCRIPTION
## Summary
- clean up imports in integration tests

## Testing
- `pytest -q` *(fails: Import error during startup test)*

------
https://chatgpt.com/codex/tasks/task_e_6841d343fad8832098fa34a735bdfb5e