### PR TITLE
Remove unused logging import

### DIFF
--- a/create_schema_only.py
+++ b/create_schema_only.py
@@ -7,7 +7,6 @@ This script only creates the database tables without importing data
 import psycopg2
 import json
 from pathlib import Path
-import logging
 
 def load_config():
     """Load configuration from JSON file"""


### PR DESCRIPTION
## Summary
- cleanup: remove unused `logging` import in `create_schema_only.py`

## Testing
- `python create_schema_only.py` *(fails: neon_config.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d34611288320b80bcd21a3ae53ba